### PR TITLE
Fix growing population

### DIFF
--- a/Feedback-and-Improvements/Chapter04/elitism.py
+++ b/Feedback-and-Improvements/Chapter04/elitism.py
@@ -48,6 +48,7 @@ def eaSimpleWithElitism(population, toolbox, cxpb, mutpb, ngen, stats=None,
 
         # Update the hall of fame with the generated individuals
         halloffame.update(offspring)
+        hof_size = len(halloffame)
 
         # Replace the current population by the offspring
         population[:] = offspring


### PR DESCRIPTION
There's a case — not included in the book, but easily discoverable — when elitism leads to uncontrollable population growth.
When starting evolution "from ground up" (e.g. when genotype is filled with zeros, similar to what used in NEAT) all individuals are started equal and the first call to `halloffame.update(population)` sets length of Hall of Fame to 1 which is then not updated. That leads to all consequent generations being increased by the full Hall Of Fame list, but reduced only by outdated `hof_size` value, which gives uncontrollable population growth.